### PR TITLE
take-order.html

### DIFF
--- a/src/partials/take_order.html
+++ b/src/partials/take_order.html
@@ -91,6 +91,7 @@
                         </label>
                         <label class="take-order-form__label">
                             <select class="take-order-form__select" name="Color Option">
+                                <option>Color Option</option>
                                 <option>K9D Black Orange</option>
                                 <option>K9D Silver Grey</option>
                                 <option>K9U White Blue</option>


### PR DESCRIPTION
Виправив на своїй сторінці у графі select (там де обираємо color option), щоб автоматично при загрузці сторінки прописувало color option замість варіантів кольору. На десктопі не зміг вплинути на ширину випадаючого вікна (вона ширше ширини select) з опціями (для select). Наскільки я зрозумів, це можна виправити лише за допомогою js